### PR TITLE
Readme setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,18 @@ WMTProxy does this by creating MapProxy configurations based on the viz.json for
 
 See example_config.py for an example WSGI configuration.
 
-The WMS is available at: http://localhost/<username>/service?
 
-The WMTS is available at: http://localhost/<username>/wmts/1.0.0/WMTSCapabilities.xml
+Development
+===========
+
+Add an entry to your `/etc/hosts` file containing the line (replace
+`<cartodb_account>` with an actual cartodb account name):
+
+    127.0.0.1	<cartodb_account>.localhost
+
+
+Then run `python ./dev_config.py` to start a dev server. While running:
+
+- You can browse services at: `http://<username>.localhost/demo`
+- WMS is available at: `http://<username>.localhost/service?`
+- WMTS is available at: `http://<username>.localhost/wmts/1.0.0/WMTSCapabilities.xml`

--- a/dev_config.py
+++ b/dev_config.py
@@ -1,0 +1,19 @@
+from wmsproxy.wsgi import make_wsgi_app
+
+import logging
+log = logging.getLogger(__name__)
+
+application = make_wsgi_app(
+    config_cache_dir='cache/',
+    max_age_seconds=30*60,
+    cartodb_domain='cartodb.com'
+)
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO)
+    logging.getLogger('requests').setLevel(logging.WARN)
+
+    from mapproxy.util.ext.serving import run_simple
+    run_simple('localhost', 5050, application, use_reloader=True, processes=1,
+               threaded=True, passthrough_errors=True)
+


### PR DESCRIPTION
Adds a note about adding an entry to `/etc/hosts` so the wsgi app can pull the username name from the domain ("HTTP_HOST" in the wsgi env).

Also adds a `./dev_config.py` script that will start a dev server automatically.
