### PR TITLE
Support WMS GetFeatureInfo Requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 requests==2.2.1
 mapproxy>=1.7.1
+dicttoxml==1.6.6
+pystache==0.5.4

--- a/wmsproxy/config_writer.py
+++ b/wmsproxy/config_writer.py
@@ -6,6 +6,11 @@ from mapproxy.util.fs import write_atomic
 
 def mapproxy_config(layers, user):
     conf = {
+        #'globals': {
+            #'http': {
+                #'ssl_no_cert_checks': True,
+            #},
+        #},
         'services': {
             'wmts': {
                 'md': {'title': 'CartoDB WMTS for %s' % user, },
@@ -42,12 +47,17 @@ def mapproxy_config(layers, user):
             'sources': [name],
         })
 
-        conf['sources'][name] = {
+        source_conf = {
             'type': 'tile',
             'url': layer['url'] + '%(tms_path)s.png',
             'transparent': True,
             'grid': 'webmercator',
         }
+        if layer.get('featureinfo_utfgrid_url'):
+            source_conf['featureinfo_utfgrid_url'] = layer['featureinfo_utfgrid_url'] + '%(tms_path)s.grid.json'
+        if layer.get('featureinfo_utfgrid_template'):
+            source_conf['featureinfo_utfgrid_template'] = layer['featureinfo_utfgrid_template']
+        conf['sources'][name] = source_conf
 
         # TODO
         if False:

--- a/wmsproxy/viz.py
+++ b/wmsproxy/viz.py
@@ -109,11 +109,31 @@ def tile_params(user, uuid, cartodb_domain='cartodb.com'):
             ldef = layer['options']['named_map']['params']
             url, last_updated = tile_url(turl, ldef, user=user)
 
-            return {
+            layer_obj = {
                 'url': url,
                 'last_updated': last_updated,
                 'bounds': bounds,
                 'title': viz_doc['title'],
+            }
+
+            ssl_url, last_updated = tile_url(turl, ldef, user=user, protocol='http')
+            utfgrid_info = find_utfgrid_info(layer, ssl_url)
+            if (utfgrid_info):
+                layer_obj.update(utfgrid_info)
+
+            return layer_obj
+
+def find_utfgrid_info(layer, layer_url):
+    for i, l in enumerate(layer['options']['named_map']['layers']):
+        tooltip = l.get('tooltip')
+        if (tooltip):
+            # TODO: generalize this to work with CartoDB UI toggles by
+            # interpretting the tooltip['fields'] and iterating through the
+            # tooltip "fields"
+            utfgrid_url = '{layer_url}{layer_id}/'.format(layer_url=layer_url, layer_id=i+1)
+            return {
+                'featureinfo_utfgrid_url': utfgrid_url,
+                'featureinfo_utfgrid_template': tooltip['template'],
             }
 
 if __name__ == '__main__':

--- a/wmsproxy/viz.py
+++ b/wmsproxy/viz.py
@@ -2,7 +2,7 @@ import requests
 import json
 
 TILER_URL_TEMPLATE = '%(tiler_protocol)s://%(user_name)s.%(tiler_domain)s:%(tiler_port)s/api/v1/map'
-TILE_URL_TEMPLATE = '%(protocol)s://0.%(domain)s/%(user_name)s/api/v1/map/%(layergroupid)s/'
+TILE_URL_TEMPLATE = '%(protocol)s://%(domain)s/%(user_name)s/api/v1/map/%(layergroupid)s/'
 VIZ_URL_TEMPLATE = 'http://%(user)s.%(domain)s/api/v2/viz/%(uuid)s/viz.json'
 ALL_VIZ_TEMPLATE = 'http://%(user)s.%(domain)s/api/v1/viz/?tag_name=&q=&page=1&types=table,derived&exclude_shared=false&per_page=%(max)s&table_data=false&o%%5Bupdated_at%%5D=desc&exclude_raster=true'
 
@@ -26,7 +26,7 @@ def layer_definition(layer):
 
     return layer['options']['layer_definition']
 
-def tile_url(tiler_url, layer_definition, user):
+def tile_url(tiler_url, layer_definition, user, protocol='http'):
     try:
         resp = requests.post(
             tiler_url,
@@ -43,9 +43,14 @@ def tile_url(tiler_url, layer_definition, user):
         raise RequestError("unable to query tiler", resp)
 
     data = resp.json()
+
+    if protocol == 'http':
+        domain = '0.' + data['cdn_url'][protocol]
+    else:
+        domain = data['cdn_url'][protocol]
     url = TILE_URL_TEMPLATE % {
-        'protocol': 'http',
-        'domain': data['cdn_url']['http'],
+        'protocol': protocol,
+        'domain': domain,
         'user_name': user,
         'layergroupid': data['layergroupid'],
     }

--- a/wmsproxy/viz.py
+++ b/wmsproxy/viz.py
@@ -143,13 +143,12 @@ def _get_utfgrid_template(tooltip):
     # directly accept the UTFGrid values as a context. This will be a common
     # case, where the template was defined by the toggles in the infowindow UI
     parsed = pystache.parse(template)
-    template_nodes = [
-        i.key for i in parsed._parse_tree
-        if getattr(i, 'key', None) == 'fields'
+    template_sections = [
+        getattr(i, 'key', None)
+        for i in parsed._parse_tree
     ]
-    template_contains_fields = 'fields' in template_nodes
 
-    if not template_contains_fields:
+    if 'fields' not in template_sections:
         return template
     else:
         fields = tooltip['fields']


### PR DESCRIPTION
This depends on mapproxy/mapproxy#215, so that'll need to be merged before this will work.

This adds the corresponding setup variables to the mapproxy config that will allow GetFeatureInfo requests to work on wms-proxied CartoDB layers. It uses the utfgrids that provide the infowindow hover interactivity, so the request response can be configured via the CartoDB infowindow UI and template system.
