### PR TITLE
update to 2.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests==2.2.1
+requests==2.4.0
 mapproxy>=1.7.1


### PR DESCRIPTION
- Ticket: https://app.shortcut.com/cartoteam/story/221613/builder-test2-error-trying-to-load-a-wms-service-as-a-base-layer
- Testing updating to requests `2.4.0` to fix SSL verification errors in the WMS proxy service